### PR TITLE
refactor: remove scipy dep and vendor gmean impl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ dev = [
     "ruff",
 ]
 notebooks = [
-    "snakemake",
-    "seaborn",
     "pyarrow",
     "fastparquet",
     "matplotlib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "jinja2>=3.0.0",
     "jupyter-scatter>=0.12.2",
     "pandas>=1.0,<2.0",
-    "scipy>=1.10.1",
 ]
 dynamic = ["version"]
 

--- a/src/cev/metrics.py
+++ b/src/cev/metrics.py
@@ -112,10 +112,8 @@ def transform_abundance(
             np.fill_diagonal(mask, 1.0)
 
     if clr:
-        import scipy
-
         inflated_counts = np.fromiter(abundances.values(), dtype=int) + 1
-        gmean = scipy.stats.mstats.gmean(inflated_counts)
+        gmean = _gmean(inflated_counts)
         values = dict(zip(abundances.keys(), np.log10(inflated_counts / gmean)))
     else:
         values = abundances
@@ -153,14 +151,12 @@ def relative_abundance(abundance_representation: pd.DataFrame):
 
 
 def centered_logratio(abundance_representation: pd.DataFrame):
-    import scipy
-
     copy = abundance_representation.to_numpy().copy()
     diag = np.diagonal(copy)
     np.fill_diagonal(copy, np.where(diag > 0, diag, 1))
 
     def _compute(row, i):
-        gmean = scipy.stats.mstats.gmean(row + 1)
+        gmean = _gmean(row + 1)
         ratio = np.log10((row[i] + 1) / gmean)
         return ratio
 
@@ -168,3 +164,105 @@ def centered_logratio(abundance_representation: pd.DataFrame):
         [_compute(row, i) for i, row in enumerate(copy)],
         index=abundance_representation.index,
     )
+
+
+# from scipy.stats.mstats.gmean
+#
+# Copyright (c) 2001-2002 Enthought, Inc. 2003-2023, SciPy Developers.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+def _gmean(a, axis=0, dtype=None, weights=None):
+    r"""Compute the weighted geometric mean along the specified axis.
+
+    The weighted geometric mean of the array :math:`a_i` associated to weights
+    :math:`w_i` is:
+
+    .. math::
+
+        \exp \left( \frac{ \sum_{i=1}^n w_i \ln a_i }{ \sum_{i=1}^n w_i }
+                   \right) \, ,
+
+    and, with equal weights, it gives:
+
+    .. math::
+
+        \sqrt[n]{ \prod_{i=1}^n a_i } \, .
+
+    Parameters
+    ----------
+    a : array_like
+        Input array or object that can be converted to an array.
+    axis : int or None, optional
+        Axis along which the geometric mean is computed. Default is 0.
+        If None, compute over the whole array `a`.
+    dtype : dtype, optional
+        Type to which the input arrays are cast before the calculation is
+        performed.
+    weights : array_like, optional
+        The `weights` array must be broadcastable to the same shape as `a`.
+        Default is None, which gives each value a weight of 1.0.
+
+    Returns
+    -------
+    gmean : ndarray
+        See `dtype` parameter above.
+
+    See Also
+    --------
+    numpy.mean : Arithmetic average
+    numpy.average : Weighted average
+    hmean : Harmonic mean
+
+    References
+    ----------
+    .. [1] "Weighted Geometric Mean", *Wikipedia*,
+           https://en.wikipedia.org/wiki/Weighted_geometric_mean.
+
+    Examples
+    --------
+    >>> from scipy.stats import gmean
+    >>> gmean([1, 4])
+    2.0
+    >>> gmean([1, 2, 3, 4, 5, 6, 7])
+    3.3800151591412964
+    >>> gmean([1, 4, 7], weights=[3, 1, 3])
+    2.80668351922014
+
+    """
+
+    a = np.asarray(a, dtype=dtype)
+
+    if weights is not None:
+        weights = np.asarray(weights, dtype=dtype)
+
+    with np.errstate(divide="ignore"):
+        log_a = np.log(a)
+
+    return np.exp(np.average(log_a, axis=axis, weights=weights))


### PR DESCRIPTION
We only use one function from `scipy`, which is a large dependency. This PR just vendors that function (`gmean`). In the future, we could also vectorize the implementation for our row-wise computation.