### PR TITLE
fix: draw `-` signs properly in dark mode

### DIFF
--- a/src/cev/components/_marker_composition_logo.py
+++ b/src/cev/components/_marker_composition_logo.py
@@ -87,6 +87,8 @@ class MarkerCompositionLogo(HTMLWidget):
                     .attr("text-anchor", "middle")
                     .attr("x", d => width / 2)
                     .attr("y", d => d[1][0] * height + (d[1][1] * height / 2))
+                    .attr("fill", "currentColor")
+                    .style("color", "var(--jp-ui-font-color0)")
                     .text(d => d[1][1] < 0.2 ? "" : "-")
             })
     </script>


### PR DESCRIPTION
The `-` signs were previously always drawn in black, which rendered them invisible in darkmode. Now the color switches to white in darkmode. E.g.:

<img width="434" alt="Screenshot 2023-05-19 at 2 46 34 PM" src="https://github.com/OzetteTech/comparative-embedding-visualization/assets/84813279/b139c090-3821-487e-b82f-b9276587e40c">
