### PR TITLE
fix: pass kwargs to `from_embedding()`

### DIFF
--- a/src/cev/_embedding.py
+++ b/src/cev/_embedding.py
@@ -33,10 +33,10 @@ class Embedding:
         coords, labels, robust = _prepare_ozette(df, **kwargs)
         return cls(coords=coords, labels=labels, robust=robust)
 
-    def widgets(self):
+    def widgets(self, **kwargs):
         from ._embedding_widget import EmbeddingWidgetCollection
 
-        return EmbeddingWidgetCollection.from_embedding(self)
+        return EmbeddingWidgetCollection.from_embedding(self, **kwargs)
 
 
 def _prepare_ozette(df: pd.DataFrame, robust_only: bool = True):


### PR DESCRIPTION
A micro fix to allow customizing embeddings via `EmbeddingComparisonWidget()` (e.g., `background_color`). This did not work previously because `**kwargs` weren't passed to `from_embedding()`.