### PR TITLE
feat: hide non-robust labels in metric view

### DIFF
--- a/notebooks/getting-started.ipynb
+++ b/notebooks/getting-started.ipynb
@@ -80,8 +80,12 @@
    },
    "outputs": [],
    "source": [
-    "tissue_umap_embedding = Embedding.from_ozette(df=pd.read_parquet(\"./data/mair-2022-tissue-138-umap.pq\"))\n",
-    "tissue_ozette_embedding = Embedding.from_ozette(df=pd.read_parquet(\"./data/mair-2022-tissue-138-ozette.pq\"))"
+    "tissue_umap_embedding = Embedding.from_ozette(\n",
+    "    df=pd.read_parquet(\"./data/mair-2022-tissue-138-umap.pq\")\n",
+    ")\n",
+    "tissue_ozette_embedding = Embedding.from_ozette(\n",
+    "    df=pd.read_parquet(\"./data/mair-2022-tissue-138-ozette.pq\")\n",
+    ")"
    ]
   },
   {
@@ -126,7 +130,7 @@
    },
    "outputs": [],
    "source": [
-    "umap_vs_ozette.select(['CD3+', 'CD4+', 'CD8-'])"
+    "umap_vs_ozette.select([\"CD3+\", \"CD4+\", \"CD8-\"])"
    ]
   },
   {
@@ -148,7 +152,9 @@
    },
    "outputs": [],
    "source": [
-    "tumor_ozette_embedding = Embedding.from_ozette(df=pd.read_parquet(\"./data/mair-2022-tumor-006-ozette.pq\"))"
+    "tumor_ozette_embedding = Embedding.from_ozette(\n",
+    "    df=pd.read_parquet(\"./data/mair-2022-tumor-006-ozette.pq\")\n",
+    ")"
    ]
   },
   {
@@ -192,7 +198,9 @@
    },
    "outputs": [],
    "source": [
-    "tissue_vs_tumor.select(\"CD4-CD8+CD3+CD45RA+CD27+CD19-CD103-CD28-CD69+PD1+HLADR-GranzymeB-CD25-ICOS-TCRgd-CD38-CD127-Tim3-\")"
+    "tissue_vs_tumor.select(\n",
+    "    \"CD4-CD8+CD3+CD45RA+CD27+CD19-CD103-CD28-CD69+PD1+HLADR-GranzymeB-CD25-ICOS-TCRgd-CD38-CD127-Tim3-\"\n",
+    ")"
    ]
   },
   {

--- a/notebooks/getting-started.ipynb
+++ b/notebooks/getting-started.ipynb
@@ -80,12 +80,8 @@
    },
    "outputs": [],
    "source": [
-    "tissue_umap_embedding = Embedding.from_ozette(\n",
-    "    df=pd.read_parquet(\"./data/mair-2022-tissue-138-umap.pq\")\n",
-    ")\n",
-    "tissue_ozette_embedding = Embedding.from_ozette(\n",
-    "    df=pd.read_parquet(\"./data/mair-2022-tissue-138-ozette.pq\")\n",
-    ")"
+    "tissue_umap_embedding = Embedding.from_ozette(df=pd.read_parquet(\"./data/mair-2022-tissue-138-umap.pq\"))\n",
+    "tissue_ozette_embedding = Embedding.from_ozette(df=pd.read_parquet(\"./data/mair-2022-tissue-138-ozette.pq\"))"
    ]
   },
   {
@@ -130,7 +126,7 @@
    },
    "outputs": [],
    "source": [
-    "umap_vs_ozette.select([\"CD3+\", \"CD4+\", \"CD8-\"])"
+    "umap_vs_ozette.select(['CD3+', 'CD4+', 'CD8-'])"
    ]
   },
   {
@@ -152,9 +148,7 @@
    },
    "outputs": [],
    "source": [
-    "tumor_ozette_embedding = Embedding.from_ozette(\n",
-    "    df=pd.read_parquet(\"./data/mair-2022-tumor-006-ozette.pq\")\n",
-    ")"
+    "tumor_ozette_embedding = Embedding.from_ozette(df=pd.read_parquet(\"./data/mair-2022-tumor-006-ozette.pq\"))"
    ]
   },
   {
@@ -198,9 +192,7 @@
    },
    "outputs": [],
    "source": [
-    "tissue_vs_tumor.select(\n",
-    "    \"CD4-CD8+CD3+CD45RA+CD27+CD19-CD103-CD28-CD69+PD1+HLADR-GranzymeB-CD25-ICOS-TCRgd-CD38-CD127-Tim3-\"\n",
-    ")"
+    "tissue_vs_tumor.select(\"CD4-CD8+CD3+CD45RA+CD27+CD19-CD103-CD28-CD69+PD1+HLADR-GranzymeB-CD25-ICOS-TCRgd-CD38-CD127-Tim3-\")"
    ]
   },
   {

--- a/src/cev/_embedding_widget.py
+++ b/src/cev/_embedding_widget.py
@@ -11,7 +11,12 @@ import pandas as pd
 import traitlets
 
 from cev._embedding import Embedding
-from cev._widget_utils import create_colormaps, link_widgets, robust_labels
+from cev._widget_utils import (
+    NON_ROBUST_LABEL,
+    create_colormaps,
+    link_widgets,
+    robust_labels,
+)
 from cev.components import MarkerCompositionLogo
 
 _LABEL_COLUMN = "label"
@@ -106,6 +111,13 @@ class EmbeddingWidgetCollection(traitlets.HasTraits):
             labeling=labeling,
         )
         self.metric_scatter.legend(True)
+
+        self.metric_scatter.filter(None)
+        robust_labels = self._data.query(
+            f"{_ROBUST_LABEL_COLUMN} != '{NON_ROBUST_LABEL}'"
+        )
+        if len(robust_labels):
+            self.metric_scatter.filter(robust_labels.index)
 
     @traitlets.observe("colormap")
     def _update_categorical_scatter(self, *args, **kwargs):


### PR DESCRIPTION
Adds your fix for hiding non-robust to declutter the metric views.